### PR TITLE
set engine data for node/npm in package.json

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,20 +1,22 @@
-var fs = require('fs');
-var path = require('path');
-var http = require('http');
-var express = require('express');
-var session = require('express-session');
-var RED = require('e-node-red');
-var settings = require('./settings');
-var bodyParser = require('body-parser');
-var app = express();
+var fs = require('fs')
+var path = require('path')
+var http = require('http')
+var express = require('express')
+var session = require('express-session')
+var RED = require('@uhuru/enebular-node-red')
+var settings = require('./settings')
+var bodyParser = require('body-parser')
+var app = express()
 
-var server = http.createServer(app);
+var server = http.createServer(app)
 
-app.use(bodyParser.urlencoded({
-  extended: true
-}));
+app.use(
+  bodyParser.urlencoded({
+    extended: true
+  })
+)
 
-app.use(session({ secret: '4r13ysgyYD' }));
+app.use(session({ secret: '4r13ysgyYD' }))
 
 /*
 var JWTAuth = require('./jwt');
@@ -26,18 +28,17 @@ app.all("/red/*", JWTAuth(public_key_path, {
 }));
 */
 
-app.use('/red', express.static('public'));
-app.set('view engine', 'ejs');
+app.use('/red', express.static('public'))
+app.set('view engine', 'ejs')
 
-RED.init(server, settings);
-app.use(settings.httpAdminRoot, RED.httpAdmin);
-app.use(settings.httpNodeRoot, RED.httpNode);
-app.get("/", function(req, res) {
-	res.redirect('/red');
-});
+RED.init(server, settings)
+app.use(settings.httpAdminRoot, RED.httpAdmin)
+app.use(settings.httpNodeRoot, RED.httpNode)
+app.get('/', function(req, res) {
+  res.redirect('/red')
+})
 
-var port = process.env.PORT || 1880;
-server.listen(port);
+var port = process.env.PORT || 1880
+server.listen(port)
 
-
-RED.start();
+RED.start()

--- a/mongodbstorage.js
+++ b/mongodbstorage.js
@@ -18,7 +18,7 @@ var request = require('request')
 var mongo = require('mongodb')
 var when = require('when')
 var util = require('util')
-var RED = require('e-node-red')
+var RED = require('@uhuru/enebular-node-red')
 
 var settings
 

--- a/package.json
+++ b/package.json
@@ -7,8 +7,13 @@
   "scripts": {
     "start": "node app"
   },
+  "engines": {
+    "node": "8.12.0",
+    "npm": "6.0.0"
+  },
   "files": [],
   "dependencies": {
+    "@uhuru/enebular-node-red": "enebular/enebular-node-red",
     "bcryptjs": "~2.x",
     "body-parser": "^1.14.0",
     "ejs": "^2.3.4",
@@ -16,7 +21,6 @@
     "express-session": "^1.11.3",
     "jsonwebtoken": "^5.0.4",
     "mongodb": "^2.2.24",
-    "e-node-red": "github:enebular/enebular-node-red",
     "node-red-contrib-admin": "0.0.5",
     "node-red-contrib-enebular": "file:./node-red-contrib-enebular",
     "node-red-contrib-metrics": "0.0.1",


### PR DESCRIPTION
Problem: heroku would install it's preferred node version (which seems to be 10.X atm) if the `engine` info for `node` is not specified in the `package.json`

References: https://qiita.com/TakedaHiromasa/items/5618facc26654907e43b